### PR TITLE
Rewrite

### DIFF
--- a/src/bool.c
+++ b/src/bool.c
@@ -45,58 +45,35 @@ bool is_equal(scmval x, scmval y) {
 }
 
 // standard library
-static scmval scm_boolean_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_bool(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_boolean_p(scmval v) {
+    return scm_bool(is_bool(v));
 }
 
-static scmval scm_not(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_false(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_not(scmval v) {
+    return scm_bool(is_false(v));
 }
 
-static scmval scm_eq(scm_ctx_t* ctx) {
-    scmval x, y;
-    x = arg_ref(ctx, 0);
-    y = arg_ref(ctx, 1);
-    if(is_eq(x, y))
-        return scm_true;
-    return scm_false;
+static scmval scm_eq(scmval x, scmval y) {
+    return scm_bool(is_eq(x, y));
 }
 
-static scmval scm_eqv(scm_ctx_t* ctx) {
-    scmval x, y;
-    x = arg_ref(ctx, 0);
-    y = arg_ref(ctx, 1);
-    if(is_eqv(x, y))
-        return scm_true;
-    return scm_false;
+static scmval scm_eqv(scmval x, scmval y) {
+    return scm_bool(is_eqv(x, y));
 }
 
-static scmval scm_equal(scm_ctx_t* ctx) {
-    scmval x, y;
-    x = arg_ref(ctx, 0);
-    y = arg_ref(ctx, 1);
-    if(is_equal(x, y))
-        return scm_true;
-    return scm_false;
+static scmval scm_equal(scmval x, scmval y) {
+    return scm_bool(is_equal(x, y));
 }
 
 // initialization
-void init_bool(scm_ctx_t* ctx) {
+void init_bool() {
     scm_true  = make_bool(true);
     scm_false = make_bool(false);
 
-    define(ctx, "boolean?", scm_boolean_p, arity_exactly(1), 1, any_c);
-    define(ctx, "not", scm_not, arity_exactly(1), 1, any_c);
-    define(ctx, "eq?", scm_eq, arity_exactly(2), 2, any_c, any_c);
-    define(ctx, "eqv?", scm_eqv, arity_exactly(2), 2, any_c, any_c);
-    define(ctx, "equal?", scm_equal, arity_exactly(2), 2, any_c, any_c);
+    define("boolean?", scm_boolean_p, arity_exactly(1));
+    define("not", scm_not, arity_exactly(1));
+    define("eq?", scm_eq, arity_exactly(2));
+    define("eqv?", scm_eqv, arity_exactly(2));
+    define("equal?", scm_equal, arity_exactly(2));
 }
 

--- a/src/char.c
+++ b/src/char.c
@@ -8,121 +8,105 @@ scmval make_char(scm_char_t c) {
 }
 
 // standard library
-scmval scm_char_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_char(v))
-        return scm_true;
-    return scm_false;
+scmval scm_char_p(scmval v) {
+    return scm_bool(is_char(v));
 }
 
-#define make_char_comparator(CNAME, PRED, CI)       \
-    static inline scmval CNAME(scm_ctx_t* ctx) {    \
-        scm_char_t c, c1;                           \
-        bool eq;                                    \
-        int argc;                                   \
-        scmval *argv;                               \
-        arg_ref_list(ctx, &argc, &argv);            \
-        c = char_value(argv[0]);                    \
-        for(int i = 1; i < argc; i++) {             \
-            c1 = char_value(argv[i]);               \
-            eq = CI                                 \
-                ? tolower(c) PRED tolower(c1)       \
-                : c PRED c1;                        \
-            if(!eq) return scm_false;               \
-            c = c1;                                 \
-        }                                           \
-        return scm_true;                            \
+#define make_char_comparator(NAME, CNAME, PRED, CI)             \
+    static inline scmval CNAME(scmfix argc, scmval* argv) {     \
+        check_args(NAME, char_c, argc, argv);                   \
+        scm_char_t c, c1;                                       \
+        bool eq;                                                \
+        c = char_value(argv[0]);                                \
+        for(int i = 1; i < argc; i++) {                         \
+            c1 = char_value(argv[i]);                           \
+            eq = CI                                             \
+                ? tolower(c) PRED tolower(c1)                   \
+                : c PRED c1;                                    \
+            if(!eq) return scm_false;                           \
+            c = c1;                                             \
+        }                                                       \
+        return scm_true;                                        \
     }
 
-make_char_comparator(scm_char_eq_p, ==, false)
-make_char_comparator(scm_char_lt_p, <,  false)
-make_char_comparator(scm_char_gt_p, >,  false)
-make_char_comparator(scm_char_le_p, <=, false)
-make_char_comparator(scm_char_ge_p, >=, false)
+make_char_comparator("char=?",  scm_char_eq_p, ==, false)
+make_char_comparator("char<?",  scm_char_lt_p, <,  false)
+make_char_comparator("char>?",  scm_char_gt_p, >,  false)
+make_char_comparator("char<=?", scm_char_le_p, <=, false)
+make_char_comparator("char>=?", scm_char_ge_p, >=, false)
 
-make_char_comparator(scm_char_ci_eq_p, ==, true)
-make_char_comparator(scm_char_ci_lt_p, <,  true)
-make_char_comparator(scm_char_ci_gt_p, >,  true)
-make_char_comparator(scm_char_ci_le_p, <=, true)
-make_char_comparator(scm_char_ci_ge_p, >=, true)
+make_char_comparator("char-ci=?",   scm_char_ci_eq_p, ==, true)
+make_char_comparator("char-ci<?",   scm_char_ci_lt_p, <,  true)
+make_char_comparator("char-ci>?",   scm_char_ci_gt_p, >,  true)
+make_char_comparator("char-ci<=?",  scm_char_ci_le_p, <=, true)
+make_char_comparator("char-ci>=?",  scm_char_ci_ge_p, >=, true)
 
 #undef make_char_comparator
 
-#define make_char_predicate(CNAME, PRED)            \
-    static inline scmval CNAME(scm_ctx_t* ctx) {    \
-        scmval v;                                   \
-        v = arg_ref(ctx, 0);                        \
-        if(PRED(char_value(v)))                     \
-            return scm_true;                        \
-        return scm_false;                           \
+#define make_char_predicate(NAME, CNAME, PRED)  \
+    static inline scmval CNAME(scmval v) {      \
+        check_arg(NAME, char_c, v);             \
+        return scm_bool(PRED(char_value(v)));   \
     }
 
-make_char_predicate(scm_char_alphabetic_p, isalpha)
-make_char_predicate(scm_char_numeric_p, isdigit)
-make_char_predicate(scm_char_whitespace_p, isspace)
-make_char_predicate(scm_char_upper_p, isupper)
-make_char_predicate(scm_char_lower_p, islower)
+make_char_predicate("char-alphabetic?", scm_char_alphabetic_p,  isalpha)
+make_char_predicate("char-numeric?",    scm_char_numeric_p,     isdigit)
+make_char_predicate("char-whitespace?", scm_char_whitespace_p,  isspace)
+make_char_predicate("char-upper-case?", scm_char_upper_p,       isupper)
+make_char_predicate("char-lower-case?", scm_char_lower_p,       islower)
 
 #undef make_char_predicate
 
-static inline scmval scm_char_digit_value(scm_ctx_t* ctx) {
-    scm_char_t c;
-    scmval v;
-    v = arg_ref(ctx, 0);
-    c = char_value(v);
+static inline scmval scm_char_digit_value(scmval v) {
+    check_arg("digit-value", char_c, v);
+    scm_char_t c = char_value(v);
     if(isdigit(c))
         return make_fixnum(c - '0');
     return scm_false;
 }
 
-static inline scmval scm_char_to_integer(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
+static inline scmval scm_char_to_integer(scmval v) {
+    check_arg("char->integer", char_c, v);
     return make_fixnum(char_value(v));
 }
 
-static inline scmval scm_integer_to_char(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
+static inline scmval scm_integer_to_char(scmval v) {
+    check_arg("integer->char", fixnum_c, v);
     // FIXME check value to prevent overflow
     return make_char((scm_char_t)fixnum_value(v));
 }
 
-static inline scmval scm_char_upcase(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
+static inline scmval scm_char_upcase(scmval v) {
+    check_arg("char-upcase", char_c, v);
     return make_char(toupper(char_value(v)));
 }
 
-static inline scmval scm_char_downcase(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
+static inline scmval scm_char_downcase(scmval v) {
+    check_arg("char-downcase", char_c, v);
     return make_char(tolower(char_value(v)));
 }
 
-void init_char(scm_ctx_t* ctx) {
-    define(ctx, "char?", scm_char_p, arity_exactly(1), 1, any_c);
-    define(ctx, "char=?",  scm_char_eq_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char<?",  scm_char_lt_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char>?",  scm_char_gt_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char<=?", scm_char_le_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char>=?", scm_char_ge_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char-ci=?",  scm_char_ci_eq_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char-ci<?",  scm_char_ci_lt_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char-ci>?",  scm_char_ci_gt_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char-ci<=?", scm_char_ci_le_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char-ci>=?", scm_char_ci_ge_p, arity_at_least(2), 1, char_c);
-    define(ctx, "char-alphabetic?", scm_char_alphabetic_p, arity_exactly(1), 1, char_c);
-    define(ctx, "char-numeric?", scm_char_numeric_p, arity_exactly(1), 1, char_c);
-    define(ctx, "char-whitespace?", scm_char_whitespace_p, arity_exactly(1), 1, char_c);
-    define(ctx, "char-upper-case?", scm_char_upper_p, arity_exactly(1), 1, char_c);
-    define(ctx, "char-lower-case?", scm_char_lower_p, arity_exactly(1), 1, char_c);
-    define(ctx, "digit-value", scm_char_digit_value, arity_exactly(1), 1, char_c);
-    define(ctx, "char->integer", scm_char_to_integer, arity_exactly(1), 1, char_c);
-    define(ctx, "integer->char", scm_integer_to_char, arity_exactly(1), 1, fixnum_c);
-    define(ctx, "char-upcase", scm_char_upcase, arity_exactly(1), 1, char_c);
-    define(ctx, "char-downcase", scm_char_downcase, arity_exactly(1), 1, char_c);
-
+void init_char() {
+    define("char?", scm_char_p, arity_exactly(1));
+    define("char=?",  scm_char_eq_p, arity_at_least(2));
+    define("char<?",  scm_char_lt_p, arity_at_least(2));
+    define("char>?",  scm_char_gt_p, arity_at_least(2));
+    define("char<=?", scm_char_le_p, arity_at_least(2));
+    define("char>=?", scm_char_ge_p, arity_at_least(2));
+    define("char-ci=?",  scm_char_ci_eq_p, arity_at_least(2));
+    define("char-ci<?",  scm_char_ci_lt_p, arity_at_least(2));
+    define("char-ci>?",  scm_char_ci_gt_p, arity_at_least(2));
+    define("char-ci<=?", scm_char_ci_le_p, arity_at_least(2));
+    define("char-ci>=?", scm_char_ci_ge_p, arity_at_least(2));
+    define("char-alphabetic?", scm_char_alphabetic_p, arity_exactly(1));
+    define("char-numeric?", scm_char_numeric_p, arity_exactly(1));
+    define("char-whitespace?", scm_char_whitespace_p, arity_exactly(1));
+    define("char-upper-case?", scm_char_upper_p, arity_exactly(1));
+    define("char-lower-case?", scm_char_lower_p, arity_exactly(1));
+    define("digit-value", scm_char_digit_value, arity_exactly(1));
+    define("char->integer", scm_char_to_integer, arity_exactly(1));
+    define("integer->char", scm_integer_to_char, arity_exactly(1));
+    define("char-upcase", scm_char_upcase, arity_exactly(1));
+    define("char-downcase", scm_char_downcase, arity_exactly(1));
 }
 

--- a/src/context.c
+++ b/src/context.c
@@ -2,34 +2,11 @@
 
 #include "scm.h"
 
-scm_ctx_t* init_context() {
-    scm_ctx_t* ctx = scm_new(scm_ctx_t);
-    ctx->symbols  = make_dict();
-    ctx->globals  = make_dict();
-    ctx->toplevel = make_env(scm_undef);
-    ctx->stack = NULL;
-    return ctx;
-}
+scm_ctx_t scm_context;
 
-void push_frame(scm_ctx_t* ctx, size_t n) {
-    stack_frame_t* stack = ctx->stack;
-    stack_frame_t* frame = scm_new(stack_frame_t);
-    frame->argc = n;
-    frame->argv = NULL;
-    if(n > 0) {
-        frame->argv = scm_new_array(n, scmval);
-    }
-    frame->next = stack;
-    ctx->stack = frame;
-}
-
-void pop_frame(scm_ctx_t* ctx) {
-    stack_frame_t* top = ctx->stack;
-    if(top == NULL) {
-        ctx->stack = NULL;
-    } else {
-        ctx->stack = top->next;
-    }
-    scm_delete(top);
+void init_context() {
+    scm_context.symbols  = make_dict();
+    scm_context.globals  = make_dict();
+    scm_context.toplevel = make_env(scm_undef);
 }
 

--- a/src/env.c
+++ b/src/env.c
@@ -9,7 +9,7 @@ scmval make_env(scmval n) {
 }
 
 // utilities
-void define(const char* name, subr fun, arity_t arity) {
+void define(const char* name, subr_f fun, arity_t arity) {
     scmval s = make_subr(name, fun, arity);
     dict_set(scm_context.globals, intern(name), s);
 }

--- a/src/env.c
+++ b/src/env.c
@@ -9,15 +9,12 @@ scmval make_env(scmval n) {
 }
 
 // utilities
-void define(scm_ctx_t* ctx, const char* name, scm_prim_fun fun, arity_t arity, int n, ...) {
-    va_list ap;
-    va_start(ap, n);
-    scmval prim = make_primv(name, fun, arity, n, ap);
-    va_end(ap);
-    dict_set(ctx->globals, intern(ctx, name), prim);
+void define(const char* name, subr fun, arity_t arity) {
+    scmval s = make_subr(name, fun, arity);
+    dict_set(scm_context.globals, intern(name), s);
 }
 
-scmval lookup(scm_ctx_t* ctx, scmval e, scmval s) {
+scmval lookup(scmval e, scmval s) {
     scmval v;
     while(!is_undef(e)) {
         v = dict_ref(env_bindings(e), s);
@@ -26,10 +23,10 @@ scmval lookup(scm_ctx_t* ctx, scmval e, scmval s) {
         e = env_next(e);
     }
 
-    return dict_ref(ctx->globals, s);
+    return dict_ref(scm_context.globals, s);
 }
 
-void bind(scm_ctx_t* ctx, scmval e, scmval s, scmval v) {
+void bind(scmval e, scmval s, scmval v) {
     dict_set(env_bindings(e), s, v);
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -3,7 +3,7 @@
 // globals
 scmval range_error_type;
 scmval arity_error_type;
-scmval contract_error_type;
+scmval type_error_type;
 
 // constructor
 scmval make_error(scmval type, scmval message) {
@@ -14,15 +14,15 @@ scmval make_error(scmval type, scmval message) {
 }
 
 // standard library
-void throw(scm_ctx_t* ctx, scmval e) {
-    set_error(ctx, e);
-    longjmp(ctx->err_buf, 1);
+void raise(scmval e) {
+    set_error(e);
+    longjmp(scm_context.err_buf, 1);
 }
 
 // initialization
-void init_errors(scm_ctx_t* ctx) {
-    range_error_type = intern(ctx, "range-error");
-    arity_error_type = intern(ctx, "arity-error");
-    contract_error_type = intern(ctx, "contract-error");
+void init_errors() {
+    type_error_type  = intern("type-error");
+    range_error_type = intern("range-error");
+    arity_error_type = intern("arity-error");
 }
 

--- a/src/port.c
+++ b/src/port.c
@@ -4,157 +4,116 @@
 scmval scm_eof;
 
 // constructors
-scmval make_input_port(enum port_type type, void* p, ip_vtable* vtable) {
-    scm_input_port_t* ip = scm_new(scm_input_port_t);
-    ip->type = type;
-    ip->port = p;
-    ip->open = true;
-    ip->line = 1;
-    ip->pos  = 0;
-    ip->vtable = vtable;
-    return make_ptr(SCM_TYPE_INPUT_PORT, ip);
+scmval make_port(scmfix flags, void* data, char* name, scm_port_vtable_t* vtable) {
+    scm_port_t* port = scm_new(scm_port_t);
+    port->flags  = flags;
+    port->data   = data;
+    port->name   = name;
+    port->open   = true;
+    port->line   = 1;
+    port->pos    = 0;
+    port->vtable = vtable;
+    return make_ptr(SCM_TYPE_PORT, port);
 }
 
-scmval make_output_port(enum port_type type, void* p, outp_vtable* vtable) {
-    scm_output_port_t* outp = scm_new(scm_output_port_t);
-    outp->type = type;
-    outp->port = p;
-    outp->open = true;
-    outp->vtable = vtable;
-    return make_ptr(SCM_TYPE_OUTPUT_PORT, outp);
-}
 // ports creation
-static scmval make_file_input_port(FILE*);
+static scmval make_file_input_port(FILE*, char*);
 static scmval make_file_input_port_from_filename(scmval);
 static scmval make_string_input_port(scmval);
-static scmval make_file_output_port(FILE*);
+static scmval make_file_output_port(FILE*, char*);
 static scmval make_file_output_port_from_filename(scmval);
 static scmval make_string_output_port();
 
 // port procedures
-static scmval scm_port_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_port(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_port_p(scmval v) {
+    return scm_bool(is_port(v));
 }
 
-static scmval scm_input_port_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_input_port(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_input_port_p(scmval v) {
+    return scm_bool(is_input_port(v));
 }
 
-static scmval scm_output_port_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_output_port(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_output_port_p(scmval v) {
+    return scm_bool(is_output_port(v));
 }
 
-static scmval scm_eof_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_eof(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_eof_p(scmval v) {
+    return scm_bool(is_eof(v));
 }
 
-static scmval scm_port_open_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_port_open(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_port_open_p(scmval v) {
+    check_arg("port-open?", port_c, v);
+    return scm_bool(is_port_open(v));
 }
 
-static scmval scm_current_input_port(scm_ctx_t* ctx) {
-    return ctx->current_input_port;
+static scmval scm_current_input_port() {
+    return scm_context.current_input_port;
 }
 
-static scmval scm_current_output_port(scm_ctx_t* ctx) {
-    return ctx->current_output_port;
+scmval scm_current_output_port() {
+    return scm_context.current_output_port;
 }
 
-static scmval scm_current_error_port(scm_ctx_t* ctx) {
-    return ctx->current_error_port;
+scmval scm_current_error_port() {
+    return scm_context.current_error_port;
 }
 
-static scmval scm_open_input_string(scm_ctx_t* ctx) {
-    scmval p, v;
-    v = arg_ref(ctx, 0);
-    p = make_string_input_port(v);
-    return p;
+static scmval scm_open_input_string(scmval v) {
+    check_arg("open-input-string", string_c, v);
+    return  make_string_input_port(v);
 }
 
-static scmval scm_open_input_file(scm_ctx_t* ctx) {
-    scmval p, v;
-    v = arg_ref(ctx, 0);
-    p = make_file_input_port_from_filename(v);
-    return p;
+static scmval scm_open_input_file(scmval v) {
+    check_arg("open-input-file", string_c, v);
+    return make_file_input_port_from_filename(v);
 }
 
-static scmval scm_close_input_port(scm_ctx_t* ctx) {
-    scmval p;
-    p = arg_ref(ctx, 0);
-    input_port_close(p);
+static scmval scm_close_input_port(scmval p) {
+    check_arg("close-input-port", input_port_c, p);
+    port_close(p);
     return scm_undef;
 }
 
-static scmval scm_open_output_file(scm_ctx_t* ctx) {
-    scmval p, v;
-    v = arg_ref(ctx, 0);
-    p = make_file_output_port_from_filename(v);
-    return p;
+static scmval scm_open_output_file(scmval v) {
+    check_arg("open-output-file", string_c, v);
+    return make_file_output_port_from_filename(v);
 }
 
-static scmval scm_open_output_string(scm_ctx_t* ctx) {
-    scmval p;
-    p = make_string_output_port();
-    return p;
+static scmval scm_open_output_string() {
+    return make_string_output_port();
 }
 
-static scmval scm_get_output_string(scm_ctx_t* ctx) {
-    scmval v;
-    scm_string_t* s;
-    v = arg_ref(ctx, 0);
-    s = output_port_port(v);
+static scmval scm_get_output_string(scmval p) {
+    check_arg("get-output-string", output_string_port_c, p);
+    scm_string_t* s = port_data(p);
     return make_ptr(SCM_TYPE_STRING, s);
 }
 
-static scmval scm_close_output_port(scm_ctx_t* ctx) {
-    scmval p;
-    p = arg_ref(ctx, 0);
-    output_port_close(p);
+static scmval scm_close_output_port(scmval p) {
+    check_arg("close-output-port", output_port_c, p);
+    port_close(p);
     return scm_undef;
 }
 
-static scmval scm_read_char(scm_ctx_t* ctx) {
-    scmval c, p;
-    p = arg_ref(ctx, 0);
-    c = input_port_getc(p);
-    return c;
+static scmval scm_read_char(scmval p) {
+    check_arg("read-char", input_port_c, p);
+    return port_getc(p);
 }
 
-static scmval scm_peek_char(scm_ctx_t* ctx) {
-    scmval c, p;
-    p = arg_ref(ctx, 0);
-    c = input_port_getc(p);
+static scmval scm_peek_char(scmval p) {
+    check_arg("peek-char", input_port_c, p);
+    scmval c = port_getc(p);
     if(is_eof(c))
         return scm_eof;
-    c = input_port_ungetc(p, c);
+    c = port_ungetc(p, c);
     return c;
 }
 
-static scmval scm_read_line(scm_ctx_t* ctx) {
+static scmval scm_read_line(scmval p) {
+    check_arg("read-line", input_port_c, p);
     int i = 0, len = 1024;
     scm_char_t* buf, c;
-    scmval v, p;
-    p = arg_ref(ctx, 0);
+    scmval v;
     buf = scm_new_array(len, scm_char_t);
     while(true) {
         c = scm_getc(p);
@@ -171,80 +130,137 @@ static scmval scm_read_line(scm_ctx_t* ctx) {
     return v;
 }
 
-static scmval scm_write(scm_ctx_t* ctx) {
-    scmval v, p;
-    v = arg_ref(ctx, 0);
-    p = arg_ref_opt(ctx, 1, ctx->current_output_port);
-    write(p, v, WRITE_MODE_WRITE);
+static scmval scm_write(scmval v, scmval p) {
+    opt_arg(p, scm_current_output_port());
+    check_arg("write", output_port_c, p);
+    write(p, v, scm_mode_write);
     return scm_undef;
 }
 
-static scmval scm_write_char(scm_ctx_t* ctx) {
-    scmval v, p;
-    v = arg_ref(ctx, 0);
-    p = arg_ref_opt(ctx, 1, ctx->current_output_port);
-    output_port_putc(p, v);
+static scmval scm_write_char(scmval v, scmval p) {
+    opt_arg(p, scm_current_output_port());
+    check_arg("write-char", output_port_c, p);
+    port_putc(p, v);
     return scm_undef;
 }
 
-static scmval scm_display(scm_ctx_t* ctx) {
-    scmval v, p; //, s;
-    v = arg_ref(ctx, 0);
-    p = arg_ref_opt(ctx, 1, ctx->current_output_port);
-    write(p, v, WRITE_MODE_DISPLAY);
+static scmval scm_display(scmval v, scmval p) {
+    opt_arg(p, scm_current_output_port());
+    check_arg("display", output_port_c, p);
+    write(p, v, scm_mode_display);
     return scm_undef;
 }
 
-static scmval scm_newline(scm_ctx_t* ctx) {
-    scmval p;
-    p = arg_ref_opt(ctx, 0, ctx->current_output_port);
-    output_port_putc(p, make_char('\n'));
+static scmval scm_newline(scmval p) {
+    opt_arg(p, scm_current_output_port());
+    check_arg("newline", output_port_c, p);
+    port_putc(p, make_char('\n'));
     return scm_undef;
 }
 
-static scmval scm_flush_output_port(scm_ctx_t* ctx) {
-    scmval p;
-    p = arg_ref_opt(ctx, 0, ctx->current_output_port);
-    output_port_flush(p);
+static scmval scm_flush_output_port(scmval p) {
+    opt_arg(p, scm_current_output_port());
+    check_arg("flush-output-port", output_port_c, p);
+    port_flush(p);
     return scm_undef;
 }
 
 void init_port(scm_ctx_t* ctx) {
     scm_eof   = make_val(SCM_TYPE_EOF);
 
-    ctx->current_output_port = make_file_output_port(stdout);
-    ctx->current_error_port  = make_file_output_port(stderr);
-    ctx->current_input_port  = make_file_input_port(stdin);
+    scm_context.current_output_port = make_file_output_port(stdout, "stdout");
+    scm_context.current_error_port  = make_file_output_port(stderr, "stderr");
+    scm_context.current_input_port  = make_file_input_port(stdin, "stdin");
 
-    define(ctx, "port?", scm_port_p, arity_exactly(1), 1, any_c);
-    define(ctx, "input-port?", scm_input_port_p, arity_exactly(1), 1, any_c);
-    define(ctx, "output-port?", scm_output_port_p, arity_exactly(1), 1, any_c);
-    define(ctx, "eof-object?", scm_eof_p, arity_exactly(1), 1, any_c);
-    define(ctx, "port-open?", scm_port_open_p, arity_exactly(1), 1, port_c);
-    define(ctx, "current-input-port", scm_current_input_port, arity_exactly(0), 0);
-    define(ctx, "current-output-port", scm_current_output_port, arity_exactly(0), 0);
-    define(ctx, "current-error-port", scm_current_error_port, arity_exactly(0), 0);
-    define(ctx, "open-input-string", scm_open_input_string, arity_exactly(1), 1, string_c);
-    define(ctx, "open-input-file", scm_open_input_file, arity_exactly(1), 1, string_c);
-    define(ctx, "close-input-port", scm_close_input_port, arity_exactly(1), 1, input_port_c);
-    define(ctx, "open-output-string", scm_open_output_string, arity_exactly(1), 0);
-    define(ctx, "get-output-string", scm_get_output_string, arity_exactly(1), 1, output_port_c);
-    define(ctx, "open-output-file", scm_open_output_file, arity_exactly(1), 1, string_c);
-    define(ctx, "close-output-port", scm_close_output_port, arity_exactly(1), 1, output_port_c);
-    define(ctx, "read-char", scm_read_char, arity_exactly(1), 1, input_port_c);
-    define(ctx, "peek-char", scm_peek_char, arity_exactly(1), 1, input_port_c);
-    define(ctx, "read-line", scm_read_line, arity_exactly(1), 1, input_port_c);
-    define(ctx, "write", scm_write, arity_or(1, 2), 2, any_c, output_port_c);
-    define(ctx, "write-char", scm_write_char, arity_or(1, 2), 2, char_c, output_port_c);
-    define(ctx, "display", scm_display, arity_or(1, 2), 2, any_c, output_port_c);
-    define(ctx, "newline", scm_newline, arity_or(0, 1), 1, output_port_c);
-    define(ctx, "flush-output-port", scm_flush_output_port, arity_or(0, 1), 1, output_port_c);
+    define("port?", scm_port_p, arity_exactly(1));
+    define("input-port?", scm_input_port_p, arity_exactly(1));
+    define("output-port?", scm_output_port_p, arity_exactly(1));
+    define("eof-object?", scm_eof_p, arity_exactly(1));
+    define("port-open?", scm_port_open_p, arity_exactly(1));
+    define("current-input-port", scm_current_input_port, arity_exactly(0));
+    define("current-output-port", scm_current_output_port, arity_exactly(0));
+    define("current-error-port", scm_current_error_port, arity_exactly(0));
+    define("open-input-string", scm_open_input_string, arity_exactly(1));
+    define("open-input-file", scm_open_input_file, arity_exactly(1));
+    define("close-input-port", scm_close_input_port, arity_exactly(1));
+    define("open-output-string", scm_open_output_string, arity_exactly(0));
+    define("get-output-string", scm_get_output_string, arity_exactly(1));
+    define("open-output-file", scm_open_output_file, arity_exactly(1));
+    define("close-output-port", scm_close_output_port, arity_exactly(1));
+    define("read-char", scm_read_char, arity_exactly(1));
+    define("peek-char", scm_peek_char, arity_exactly(1));
+    define("read-line", scm_read_line, arity_exactly(1));
+    define("write", scm_write, arity_or(1, 2));
+    define("write-char", scm_write_char, arity_or(1, 2));
+    define("display", scm_display, arity_or(1, 2));
+    define("newline", scm_newline, arity_or(0, 1));
+    define("flush-output-port", scm_flush_output_port, arity_or(0, 1));
 }
 
-// INPUT PORTS implementations
+////////////////////////////////////////////////////////////////////////////////
+// U T I L I T I E S
+////////////////////////////////////////////////////////////////////////////////
+scmval open_input_string(const char* s) {
+    return make_string_input_port(make_string(s));
+}
+
+scmval scm_to_string(scmval v) {
+    scmval p = scm_open_output_string();
+    scm_write(v, p);
+    scm_close_output_port(p);
+    return scm_get_output_string(p);
+}
+
+scm_char_t scm_getc(scmval p) {
+    scmval c = port_getc(p);
+    if(is_eof(c))
+        return EOF;
+    if(char_value(c) == '\n') port_line(p)++;
+    port_pos(p)++;
+    return char_value(c);
+}
+
+void scm_ungetc(scmval p, scm_char_t c) {
+    port_ungetc(p, make_char(c));
+    if(c == '\n') port_line(p)--;
+    port_pos(p)--;
+}
+
+scm_char_t scm_peek(scmval p) {
+    scm_char_t c = scm_getc(p);
+    port_ungetc(p, make_char(c));
+    return c;
+}
+void scm_putc(scmval p, scm_char_t c) { 
+    port_putc(p, make_char(c)); 
+}
+
+void scm_puts(scmval p, CORD c) {
+    port_puts(p, make_string_from_cord(c)); 
+}
+
+void scm_printf(scmval p, CORD format, ...) {
+    CORD r;
+    va_list ap;
+    va_start(ap, format);
+    CORD_vsprintf(&r, format, ap);
+    va_end(ap);
+    scm_puts(p, r);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// P O R T S  I M P L E M E N T A T I O N S
+////////////////////////////////////////////////////////////////////////////////
 // -- FILE
+static void file_close(scmval op) {
+    FILE* fp = port_data(op);
+    set_port_open(op, false);
+    fclose(fp);
+}
+
 static scmval file_getc(scmval p) {
-    FILE* fp = input_port_port(p);
+    FILE* fp = port_data(p);
     if(feof(fp))
         return scm_eof;
     char c = getc(fp);
@@ -254,7 +270,7 @@ static scmval file_getc(scmval p) {
 }
 
 static scmval file_ungetc(scmval p, scmval c) {
-    FILE* fp = input_port_port(p);
+    FILE* fp = port_data(p);
     if(feof(fp))
         return scm_eof;
     char ch = ungetc(char_value(c), fp);
@@ -267,27 +283,53 @@ static scmval file_char_ready(scmval p) {
     return scm_false;
 }
 
-static void file_ip_close(scmval p) {
-    FILE* fp = input_port_port(p);
-    fclose(fp);
-    set_port_open(p, false);
+static void file_putc(scmval op, scmval v) {
+    FILE* fp = port_data(op);
+    fputc(char_value(v), fp);
 }
 
-static scmval make_file_input_port(FILE* fp) {
-    static struct ip_vtable vtable = { file_getc, file_ungetc, file_char_ready, file_ip_close };
-    scmval p = make_input_port(FILE_PORT, fp, &vtable);
+static void file_puts(scmval op, scmval v) {
+    FILE* fp = port_data(op);
+    CORD_fprintf(fp, "%r", string_value(v));
+}
+
+static void file_flush(scmval op) {
+    FILE* fp = port_data(op);
+    fflush(fp);
+}
+
+static scmval make_file_input_port(FILE* fp, char* name) {
+    static scm_port_vtable_t vtable = { file_close, file_getc, file_ungetc, file_char_ready, NULL, NULL, NULL };
+    scmval p = make_port(scm_port_input | scm_port_file, fp, name, &vtable);
     return p;
 }
 
 static scmval make_file_input_port_from_filename(scmval f) {
     FILE* fp = fopen(string_value(f), "r");
     // XXX
-    return make_file_input_port(fp);
+    return make_file_input_port(fp, string_to_cstr(f));
 }
 
+static scmval make_file_output_port(FILE* fp, char* name) {
+    static scm_port_vtable_t vtable = { file_close, NULL, NULL, NULL, file_putc, file_puts, file_flush };
+    return make_port(scm_port_output | scm_port_file, fp, name, &vtable);
+}
+
+static scmval make_file_output_port_from_filename(scmval f) {
+    FILE* fp = fopen(string_value(f), "w");
+    return make_file_output_port(fp, string_to_cstr(f));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // -- STRING
+static void string_close(scmval p) {
+    if(is_input_port(p))
+        scm_delete(port_data(p));
+    set_port_open(p, false);
+}
+
 static scmval string_getc(scmval p) {
-    scm_input_string_t* in = input_port_port(p);
+    scm_input_string_t* in = port_data(p);
     if(in->idx >= in->len)
         return scm_eof;
     char c = in->buf[in->idx++];
@@ -295,7 +337,7 @@ static scmval string_getc(scmval p) {
 }
 
 static scmval string_ungetc(scmval p, scmval c) {
-    scm_input_string_t* in = input_port_port(p);
+    scm_input_string_t* in = port_data(p);
     if(in->idx <= 0)
         return scm_eof;
     in->idx--;
@@ -303,92 +345,37 @@ static scmval string_ungetc(scmval p, scmval c) {
 }
 
 static scmval string_char_ready(scmval p) {
-    scm_input_string_t* in = input_port_port(p);
-    if(in->idx >= in->len)
-        return scm_false;
-    return scm_true;
+    scm_input_string_t* in = port_data(p);
+    return scm_bool(in->idx >= in->len);
 }
 
-static void string_ip_close(scmval p) {
-    scm_delete(input_port_port(p));
-    set_port_open(p, false);
-}
-
-static scmval make_string_input_port(scmval s) {
-    static struct ip_vtable vtable = { string_getc, string_ungetc, string_char_ready, string_ip_close };
-    scmval p;
-    scm_input_string_t* in = scm_new(scm_input_string_t);
-    in->buf = CORD_to_const_char_star(string_value(s));
-    in->idx = 0;
-    in->len = strlen(in->buf);
-    p = make_input_port(STRING_PORT, in, &vtable);
-    return p;
-}
-
-// OUTPUT PORTS implementations
-// -- FILE
-static void file_putc(scmval op, scmval v) {
-    FILE* fp = output_port_port(op);
-    fputc(char_value(v), fp);
-}
-
-static void file_puts(scmval op, scmval v) {
-    FILE* fp = output_port_port(op);
-    CORD_fprintf(fp, "%r", string_value(v));
-}
-
-static void file_flush(scmval op) {
-    FILE* fp = output_port_port(op);
-    fflush(fp);
-}
-
-static void file_close(scmval op) {
-    FILE* fp = output_port_port(op);
-    set_port_open(op, false);
-    fclose(fp);
-}
-
-static scmval make_file_output_port(FILE* fp) {
-    static outp_vtable vtable = { file_putc, file_puts, file_flush, file_close };
-    scmval v;
-    v = make_output_port(FILE_PORT, fp, &vtable);
-    return v;
-}
-
-static scmval make_file_output_port_from_filename(scmval f) {
-    FILE* fp = fopen(string_value(f), "w");
-    return make_file_output_port(fp);
-}
-
-// -- STRING
 static void string_putc(scmval p, scmval v) {
-    scm_string_t* s = output_port_port(p);
+    scm_string_t* s = port_data(p);
     CORD c = CORD_chars(char_value(v), 1);
     s->value = CORD_cat(s->value, c);
 }
 
 static void string_puts(scmval p, scmval v) {
-    scm_string_t* s = output_port_port(p);
+    scm_string_t* s = port_data(p);
     s->value = CORD_cat(s->value, string_value(v));
 }
 
 static void string_flush(scmval p) {
 }
 
-static void string_close(scmval p) {
-    set_port_open(p, false);
+static scmval make_string_input_port(scmval s) {
+    static scm_port_vtable_t vtable = { string_close, string_getc, string_ungetc, string_char_ready, NULL, NULL, NULL };
+    scm_input_string_t* in = scm_new(scm_input_string_t);
+    in->buf = CORD_to_const_char_star(string_value(s));
+    in->idx = 0;
+    in->len = strlen(in->buf);
+    return make_port(scm_port_input | scm_port_string, in, "string", &vtable);
 }
 
 static scmval make_string_output_port() {
-    static outp_vtable vtable = { string_putc, string_puts, string_flush, string_close };
-    scmval v;
+    static scm_port_vtable_t vtable = { string_close, NULL, NULL, NULL, string_putc, string_puts, string_flush };
     scm_string_t* s = scm_new(scm_string_t);
     s->value = NULL;
-    v = make_output_port(STRING_PORT, s, &vtable);
-    return v;
-}
-
-scmval open_input_string(const char* s) {
-    return make_string_input_port(make_string(s));
+    return make_port(scm_port_output | scm_port_string, s, "string", &vtable);
 }
 

--- a/src/proc.c
+++ b/src/proc.c
@@ -1,30 +1,17 @@
 #include "scm.h"
 
 // constructor
-scmval make_prim(const char* name, scm_prim_fun fun, arity_t arity, int n, ...) {
-    scmval p;
-    va_list ap;
-    va_start(ap, n);
-    p = make_primv(name, fun, arity, n, ap);
-    va_end(ap);
-    return p;
+scmval make_subr(const char* name, subr_f fn, arity_t arity) {
+    scm_subr_t* subr = scm_new(scm_subr_t);
+    subr->name  = make_string(name);
+    subr->f     = fn;
+    subr->arity = arity;
+    return make_ptr(SCM_TYPE_SUBR, subr);
 }
 
-scmval make_primv(const char* name, scm_prim_fun fun, arity_t arity, int n, va_list ap) {
-    scm_prim_t* prim = scm_new(scm_prim_t);
-    prim->name  = make_string(name);
-    prim->fun   = fun;
-    prim->arity = arity;
-    prim->contracts = scm_new_array(n, contract_t);
-    prim->contract_count = n;
-    for(int i = 0; i < n; i++) {
-        prim->contracts[i] = va_arg(ap, contract_t);
-    }
-    return make_ptr(SCM_TYPE_PRIM, prim);
-}
-
-scmval make_closure(scm_fixnum_t argc, scmval* argv, scmval env, scmval body) {
+scmval make_closure(scmval name, scmfix argc, scmval* argv, scmval env, scmval body) {
     scm_closure_t* closure = scm_new(scm_closure_t);
+    closure->name = name;
     closure->argc = argc;
     closure->argv = argv;
     closure->env  = env;
@@ -33,9 +20,9 @@ scmval make_closure(scm_fixnum_t argc, scmval* argv, scmval env, scmval body) {
 }
 
 // arity
-static scmval arity_error(scmval v, int argc) {
-    arity_t arity = prim_arity(v);
-    char* n = string_to_cstr(prim_name(v));
+static void arity_error(scmval v, int argc) {
+    arity_t arity = subr_arity(v);
+    char* n = string_to_cstr(subr_name(v));
     char* m;
     switch(arity.type) {
         case ARITY_EXACTLY:
@@ -51,64 +38,57 @@ static scmval arity_error(scmval v, int argc) {
             asprintf(&m, "at least %d argument%s", arity.min, arity.min <= 1 ? "" : "s");
             break;
     }
-    return error(arity_error_type, "%s expects %s but received %d", n, m, argc);
+    error(arity_error_type, "%s expects %s but received %d", n, m, argc);
 }
 
-static void ensure_arity(scm_ctx_t* ctx, scmval v, int argc) {
-    scmval e;
+void check_arity(scmval v, scmfix argc) {
     bool match = false;
-    arity_t arity = prim_arity(v);
+    arity_t arity = subr_arity(v);
     switch(arity.type) {
-        case ARITY_EXACTLY:
-            match = (argc == arity.min);
+        case ARITY_EXACTLY:  match = (argc == arity.min); break;
+        case ARITY_OR:       match = (argc == arity.min || argc == arity.max); break;
+        case ARITY_BETWEEN:  match = (arity.min <= argc && argc <= arity.max); break;
+        case ARITY_AT_LEAST: match = (argc >= arity.min); break;
+    }
+    if(!match)
+        arity_error(v, argc);
+}
+
+scmfix argc_from_arity(scmval subr, scmfix len) {
+    scmfix argc;
+    arity_t arity = subr_arity(subr);
+    switch(arity.type) {
+        case ARITY_EXACTLY: // already checked
+        case ARITY_AT_LEAST:
+            argc = len;
             break;
         case ARITY_OR:
-            match = (argc == arity.min || argc == arity.max);
-            break;
         case ARITY_BETWEEN:
-            match = (arity.min <= argc && argc <= arity.max);
-            break;
-        case ARITY_AT_LEAST:
-            match = (argc >= arity.min);
+            argc = arity.max; // need to pad up to arity.max
             break;
     }
-    if(!match) {
-        e = arity_error(v, argc);
-        throw(ctx, e);
-    }
+    return argc;
 }
 
-// Contract
-static void ensure_contract(scm_ctx_t* ctx, scmval v, int argc, const scmval* argv) {
-    scmval e;
-    contract_t* contracts = prim_contracts(v);
-    int ncontracts = prim_contract_count(v);
-    for(int i = 0, n = 0; i < argc; i++) {
-        if(!contracts[n].pred(argv[i])) {
-            e = error(contract_error_type,
-                      "%s: contract violation (received XXX but expected %s)",
-                      string_to_cstr(prim_name(v)),
-                      contracts[n].name);
-            throw(ctx, e);
-        }
-        if((n < ncontracts - 1) || ncontracts >= argc) {
-            ++n;
+scmval apply_funcall(scmval s, scmfix argc, scmval* argv) {
+    scmval r = scm_undef;
+    if(subr_arity(s).type == ARITY_AT_LEAST) {
+        r = funcall(s, argc, argv);
+    } else {
+        switch(argc) {
+            case  0: r = funcall0(s); break;
+            case  1: r = funcall(s, argv[0]); break;
+            case  2: r = funcall(s, argv[0], argv[1]); break;
+            case  3: r = funcall(s, argv[0], argv[1], argv[2]); break;
+            case  4: r = funcall(s, argv[0], argv[1], argv[2], argv[3]); break;
+            case  5: r = funcall(s, argv[0], argv[1], argv[2], argv[3], argv[4]); break;
+            case  6: r = funcall(s, argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]); break;
+            case  7: r = funcall(s, argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]); break;
+            case  8: r = funcall(s, argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7]); break;
+            case  9: r = funcall(s, argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7], argv[8]); break;
+            case 10: r = funcall(s, argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7], argv[8], argv[9]); break;
         }
     }
-}
-
-scmval apply(scm_ctx_t* ctx, scmval prim, scmval args) {
-    scmval r, v;
-    size_t l, i;
-    l = list_length(args);
-    push_frame(ctx, l);
-    ensure_arity(ctx, prim, l);
-    for(i = 0, v = args; !is_null(v); i++, v = cdr(v)) {
-        arg_set(ctx, i, car(v));
-    }
-    ensure_contract(ctx, prim, l, ctx->stack->argv);
-    r = prim_fun(prim)(ctx);
-    pop_frame(ctx);
     return r;
 }
 

--- a/src/scm.h
+++ b/src/scm.h
@@ -15,8 +15,10 @@
 typedef struct scmval scmval;
 typedef bool scm_bool_t;
 typedef int64_t scm_fixnum_t;
+typedef scm_fixnum_t scmfix; // used a lot
 typedef double scm_flonum_t;
 typedef char scm_char_t;
+
 
 enum {
     SCM_TYPE_UNDEF,
@@ -31,11 +33,10 @@ enum {
     SCM_TYPE_PAIR,
     SCM_TYPE_VECTOR,
     SCM_TYPE_ENV,
-    SCM_TYPE_PRIM,
+    SCM_TYPE_SUBR,
     SCM_TYPE_CLOSURE,
     SCM_TYPE_ERROR,
-    SCM_TYPE_INPUT_PORT,
-    SCM_TYPE_OUTPUT_PORT
+    SCM_TYPE_PORT,
 };
 
 struct scmval {
@@ -69,12 +70,12 @@ static inline scmval make_ptr(int type, void* o) { scmval v = { .type = type, .o
 #include "scm/error.h"
 #include "scm/pair.h"
 #include "scm/vector.h"
-#include "scm/proc.h"
 #include "scm/port.h"
+#include "scm/proc.h"
 #include "scm/env.h"
 #include "scm/writer.h"
 #include "scm/reader.h"
 
 // utilities
-void init_eval(scm_ctx_t*);
-scmval eval(scm_ctx_t*, scmval, scmval);
+void init_eval();
+scmval eval(scmval, scmval);

--- a/src/scm/bool.h
+++ b/src/scm/bool.h
@@ -4,6 +4,7 @@ extern scmval scm_false;
 
 // constructors
 scmval make_bool(scm_bool_t);
+static inline scmval scm_bool(bool b) { return b ? scm_true : scm_false; }
 
 // predicates
 static inline bool is_bool(scmval v) { return type_of(v) == SCM_TYPE_BOOL; }
@@ -17,7 +18,7 @@ define_contract(bool_c, "boolean", is_bool);
 static inline scm_bool_t bool_value(scmval v) { return v.b; }
 
 // standard library
-void init_bool(scm_ctx_t*);
+void init_bool();
 static inline bool is_eq(scmval x, scmval y) { return x.o == y.o; }
 bool is_eqv(scmval, scmval);
 bool is_equal(scmval, scmval);

--- a/src/scm/char.h
+++ b/src/scm/char.h
@@ -7,4 +7,4 @@ define_contract(char_c, "character", is_char);
 // accessor
 static inline scm_char_t char_value(scmval v) { return v.c; }
 // standard library
-void init_char(scm_ctx_t*);
+void init_char();

--- a/src/scm/context.h
+++ b/src/scm/context.h
@@ -1,12 +1,4 @@
 typedef struct context scm_ctx_t;
-typedef struct stack_frame stack_frame_t;
-
-struct stack_frame {
-    scm_fixnum_t argc;
-    scmval *argv;
-    scmval err;
-    stack_frame_t* next;
-};
 
 struct context {
     scm_dict_t* symbols;
@@ -18,28 +10,13 @@ struct context {
     scmval current_error_port;
     scmval current_input_port;
 
-    stack_frame_t* stack;
-
     scmval err;
     jmp_buf err_buf;
 };
 
-scm_ctx_t* init_context();
-// Call stack
-void push_frame(scm_ctx_t*, size_t);
-void pop_frame(scm_ctx_t*);
+// Global Context
+extern scm_ctx_t scm_context;
 
-// Arguments
-static inline void arg_set(scm_ctx_t* ctx, int index, scmval val) { ctx->stack->argv[index] = val; }
-static inline scmval arg_ref(scm_ctx_t* ctx, int index) { return ctx->stack->argv[index]; }
-static inline scmval arg_ref_opt(scm_ctx_t* ctx, int index, scmval opt) {
-    if(ctx->stack->argc <= index)
-        return opt;
-    return ctx->stack->argv[index];
-}
-static inline void arg_ref_list(scm_ctx_t* ctx, int* argc, scmval** argv) {
-    *argc = ctx->stack->argc;
-    *argv = ctx->stack->argv;
-}
+void init_context();
 
-static inline void set_error(scm_ctx_t* ctx, scmval e) { ctx->err = e; }
+static inline void set_error(scmval e) { scm_context.err = e; }

--- a/src/scm/env.h
+++ b/src/scm/env.h
@@ -17,7 +17,7 @@ static inline scm_dict_t* env_bindings(scmval v) { return get_env(v)->bindings; 
 static inline scmval env_next(scmval v) { return get_env(v)->next; }
 
 // standard library
-void define(const char*, subr, arity_t);
+void define(const char*, subr_f, arity_t);
 scmval lookup(scmval, scmval);
 void bind(scmval, scmval, scmval);
 

--- a/src/scm/env.h
+++ b/src/scm/env.h
@@ -17,7 +17,7 @@ static inline scm_dict_t* env_bindings(scmval v) { return get_env(v)->bindings; 
 static inline scmval env_next(scmval v) { return get_env(v)->next; }
 
 // standard library
-void define(scm_ctx_t*, const char*, scm_prim_fun, arity_t, int, ...);
-scmval lookup(scm_ctx_t*, scmval, scmval);
-void bind(scm_ctx_t*, scmval, scmval, scmval);
+void define(const char*, subr, arity_t);
+scmval lookup(scmval, scmval);
+void bind(scmval, scmval, scmval);
 

--- a/src/scm/pair.h
+++ b/src/scm/pair.h
@@ -22,7 +22,7 @@ define_contract(list_c, "list", is_pair);
 static inline scm_pair_t* get_pair(scmval v) { return (scm_pair_t*)v.o; }
 
 // standard lib
-void init_pair(scm_ctx_t*);
+void init_pair();
 
 static inline scmval car(scmval v) { return get_pair(v)->car; }
 static inline scmval cdr(scmval v) { return get_pair(v)->cdr; }

--- a/src/scm/port.h
+++ b/src/scm/port.h
@@ -1,31 +1,22 @@
+typedef struct scm_port scm_port_t;
+typedef struct scm_port_vtable  scm_port_vtable_t;
 typedef struct scm_input_string scm_input_string_t;
-typedef struct scm_input_port scm_input_port_t;
-typedef struct ip_vtable ip_vtable;
-typedef struct scm_output_port scm_output_port_t;
-typedef struct outp_vtable outp_vtable;
 
-enum port_type { FILE_PORT, STRING_PORT };
-
-// input port
-typedef scmval (*ip_getc)(scmval);
-typedef scmval (*ip_ungetc)(scmval, scmval);
-typedef scmval (*ip_char_ready)(scmval);
-typedef void   (*ip_close)(scmval);
-
-struct ip_vtable {
-    ip_getc       getc;
-    ip_ungetc     ungetc;
-    ip_char_ready char_ready;
-    ip_close      close;
+enum {
+    scm_port_input  = 1<<0,
+    scm_port_output = 1<<1,
+    scm_port_file   = 1<<2,
+    scm_port_string = 1<<3
 };
 
-struct scm_input_port {
-    enum port_type type;
-    void*          port;
-    bool           open;
-    int            line;
-    int            pos;
-    ip_vtable*     vtable;
+struct scm_port {
+    scmfix  flags;
+    void*   data;
+    char*   name;
+    bool    open;
+    scmfix  line;
+    scmfix  pos;
+    scm_port_vtable_t* vtable;
 };
 
 struct scm_input_string {
@@ -34,103 +25,79 @@ struct scm_input_string {
     int len;
 };
 
-// output port
-typedef void (*outp_putc)(scmval, scmval);
-typedef void (*outp_puts)(scmval, scmval);
-typedef void (*outp_flush)(scmval);
-typedef void (*outp_close)(scmval);
+// vtable defs
+typedef scmval  (*scm_port_getc)(scmval);
+typedef scmval  (*scm_port_ungetc)(scmval, scmval);
+typedef scmval  (*scm_port_ready)(scmval);
+typedef void    (*scm_port_close)(scmval);
+typedef void    (*scm_port_putc)(scmval, scmval);
+typedef void    (*scm_port_puts)(scmval, scmval);
+typedef void    (*scm_port_flush)(scmval);
 
-
-struct outp_vtable {
-    outp_putc  putc;
-    outp_puts  puts;
-    outp_flush flush;
-    outp_close close;
-};
-
-struct scm_output_port {
-    enum port_type type;
-    void*          port;
-    bool           open;
-    outp_vtable*   vtable;
+struct scm_port_vtable {
+    scm_port_close  close;
+    scm_port_getc   getc;
+    scm_port_ungetc ungetc;
+    scm_port_ready  ready;
+    scm_port_putc   putc;
+    scm_port_puts   puts;
+    scm_port_flush  flush;
 };
 
 // globals
 extern scmval scm_eof;
 
-// constructors
-scmval make_input_port(enum port_type, void*, ip_vtable*);
-scmval make_output_port(enum port_type, void*, outp_vtable*);
+// constructor
+scmval make_port(scmfix, void*, char*, scm_port_vtable_t*);
+
+// accessors
+static inline scm_port_t* get_port(scmval v) { return (scm_port_t*)v.o; }
+static inline scmfix      port_flags(scmval v) { return get_port(v)->flags; }
+static inline void*       port_data(scmval v) { return get_port(v)->data; }
+static inline char*       port_name(scmval v) { return get_port(v)->name; }
+static inline bool        is_port_open(scmval v) { return get_port(v)->open; }
+static inline void        set_port_open(scmval v, bool b) { get_port(v)->open = b; }
+// macros to allow modification
+#define port_line(P)      get_port(P)->line
+#define port_pos(P)       get_port(P)->pos
 
 // predicates
 static inline bool is_eof(scmval v) { return type_of(v) == SCM_TYPE_EOF; }
-static inline bool is_output_port(scmval v) { return type_of(v) == SCM_TYPE_OUTPUT_PORT; }
-static inline bool is_input_port(scmval v) { return type_of(v) == SCM_TYPE_INPUT_PORT; }
-static inline bool is_port(scmval v) { return is_output_port(v) || is_input_port(v); }
+static inline bool is_port(scmval v) { return type_of(v) == SCM_TYPE_PORT; }
+static inline bool is_input_port(scmval v) { return is_port(v) && (port_flags(v) & scm_port_input); }
+static inline bool is_output_port(scmval v) { return is_port(v) && (port_flags(v) & scm_port_output); }
+static inline bool is_file_port(scmval v) { return is_port(v) && (port_flags(v) & scm_port_file); }
+static inline bool is_string_port(scmval v) { return is_port(v) && (port_flags(v) & scm_port_string); }
+static inline bool is_output_string_port(scmval v) { return is_output_port(v) && is_string_port(v); }
 
 // contracts
 define_contract(port_c, "port", is_port);
 define_contract(input_port_c, "input port", is_input_port);
 define_contract(output_port_c, "output port", is_output_port);
+define_contract(output_string_port_c, "output string port", is_output_string_port);
 
-
-// accessors
-static inline scm_input_port_t* get_input_port(scmval v) { return (scm_input_port_t*)v.o; }
-static inline scm_output_port_t* get_output_port(scmval v) { return (scm_output_port_t*)v.o; }
-static inline enum port_type input_port_type(scmval v) { return get_input_port(v)->type; }
-static inline enum port_type output_port_type(scmval v) { return get_output_port(v)->type; }
-static inline void* input_port_port(scmval v) { return get_input_port(v)->port; }
-static inline void* output_port_port(scmval v) { return get_output_port(v)->port; }
-static inline bool is_port_open(scmval v) { return get_output_port(v)->open; }
-static inline void set_port_open(scmval p, bool b) {
-    if(is_output_port(p)) get_output_port(p)->open = b;
-    else                  get_input_port(p)->open = b;
-} 
-static inline scmval input_port_getc(scmval p) { return get_input_port(p)->vtable->getc(p); }
-static inline scmval input_port_ungetc(scmval p, scmval c) { return get_input_port(p)->vtable->ungetc(p, c); }
-static inline void input_port_close(scmval p) { get_input_port(p)->vtable->close(p); }
-static inline void output_port_putc(scmval p, scmval v) { get_output_port(p)->vtable->putc(p, v); }
-static inline void output_port_puts(scmval p, scmval v) { get_output_port(p)->vtable->puts(p, v); }
-static inline void output_port_flush(scmval p) { get_output_port(p)->vtable->flush(p); }
-static inline void output_port_close(scmval p) { get_output_port(p)->vtable->close(p); }
-#define port_line(P) get_input_port(P)->line
-#define port_pos(P) get_input_port(P)->pos
-
+// port vtable accessors
+static inline void   port_close(scmval p) { get_port(p)->vtable->close(p); }
+static inline scmval port_getc(scmval p) { return get_port(p)->vtable->getc(p); }
+static inline scmval port_ungetc(scmval p, scmval c) { return get_port(p)->vtable->ungetc(p, c); }
+static inline scmval port_ready(scmval p) { return get_port(p)->vtable->ready(p); }
+static inline void   port_putc(scmval p, scmval v) { get_port(p)->vtable->putc(p, v); }
+static inline void   port_puts(scmval p, scmval v) { get_port(p)->vtable->puts(p, v); }
+static inline void   port_flush(scmval p) { get_port(p)->vtable->flush(p); }
 
 // standard library
-void init_port(scm_ctx_t*);
+void init_port();
 //
 // utilities
-static inline scm_char_t scm_getc(scmval p) {
-    scmval c = input_port_getc(p);
-    if(is_eof(c))
-        return EOF;
-    if(char_value(c) == '\n') port_line(p)++;
-    port_pos(p)++;
-    return char_value(c);
-}
-
-static inline void scm_ungetc(scmval p, scm_char_t c) {
-    input_port_ungetc(p, make_char(c));
-    if(c == '\n') port_line(p)--;
-    port_pos(p)--;
-}
-
-static inline scm_char_t scm_peek(scmval p) {
-    scm_char_t c = scm_getc(p);
-    input_port_ungetc(p, make_char(c));
-    return c;
-}
-static inline void scm_putc(scmval p, scm_char_t c) { output_port_putc(p, make_char(c)); }
-static inline void scm_puts(scmval p, CORD c) { output_port_puts(p, make_string_from_cord(c)); }
-
-static inline void scm_printf(scmval p, CORD format, ...) {
-    CORD r;
-    va_list ap;
-    va_start(ap, format);
-    CORD_vsprintf(&r, format, ap);
-    va_end(ap);
-    scm_puts(p, r);
-}
+scmval scm_current_output_port();
+scmval scm_current_error_port();
+scmval scm_to_string(scmval);
+// C IO
+scm_char_t  scm_getc(scmval);
+scm_char_t  scm_peek(scmval);
+void        scm_ungetc(scmval, scm_char_t);
+void        scm_putc(scmval, scm_char_t);
+void        scm_puts(scmval, CORD);
+void        scm_printf(scmval, CORD, ...);
 
 scmval open_input_string(const char*);

--- a/src/scm/reader.h
+++ b/src/scm/reader.h
@@ -1,4 +1,4 @@
 extern scmval scm_quote;
 
-void init_reader(scm_ctx_t*);
-scmval read(scm_ctx_t*, scmval);
+void init_reader();
+scmval read(scmval);

--- a/src/scm/symbol.h
+++ b/src/scm/symbol.h
@@ -15,9 +15,9 @@ define_contract(symbol_c, "symbol", is_symbol);
 static inline scm_string_t* get_symbol(scmval v) { return (scm_string_t*)v.o; }
 
 // initialization
-void init_symbol(scm_ctx_t*);
+void init_symbol();
 
 // standard library
-scmval intern(scm_ctx_t*, const char*);
+scmval intern(const char*);
 
 

--- a/src/scm/vector.h
+++ b/src/scm/vector.h
@@ -19,7 +19,7 @@ static inline bool is_vector(scmval v) { return type_of(v) == SCM_TYPE_VECTOR; }
 define_contract(vector_c, "vector", is_vector);
 
 // standard lib
-void init_vector(scm_ctx_t*);
+void init_vector();
 
 static inline size_t vector_size(scmval v) { return get_vector(v)->size; }
 static inline scmval vector_ref(scmval v, int i) { return get_vector(v)->elts[i]; }

--- a/src/scm/writer.h
+++ b/src/scm/writer.h
@@ -1,9 +1,7 @@
-enum write_mode { 
-    WRITE_MODE_WRITE,
-    WRITE_MODE_DISPLAY
+enum {
+    scm_mode_write      = 1<<0,
+    scm_mode_display    = 1<<1,
+    scm_mode_pp_quote   = 1<<2
 };
-
-typedef enum write_mode write_mode;
-
 // write : port? any?
-void write(scmval, scmval, write_mode);
+void write(scmval, scmval, scmfix);

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -11,30 +11,24 @@ scmval make_symbol(const char* s) {
 }
 
 // standard library
-scmval intern(scm_ctx_t* ctx, const char* name) {
+scmval intern(const char* name) {
     scmval r, s;
     s = make_symbol(name);
-    r = dict_ref(ctx->symbols, s);
+    r = dict_ref(scm_context.symbols, s);
     if(is_undef(r)) {
-        dict_set(ctx->symbols, s, s);
+        dict_set(scm_context.symbols, s, s);
         r = s;
     }
     return r;
 }
 
 // standard library
-static scmval scm_symbol_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_symbol(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_symbol_p(scmval v) {
+    return scm_bool(is_symbol(v));
 }
 
-static scmval scm_symbol_equal_p(scm_ctx_t* ctx) {
-    int argc;
-    scmval *argv;
-    arg_ref_list(ctx, &argc, &argv);
+static scmval scm_symbol_equal_p(scmfix argc, scmval* argv) {
+    check_args("symbol=?", symbol_c, argc, argv);
     scmval s = argv[0];
     for(int i = 1; i < argc; i++) {
         if(!is_eq(s, argv[i]))
@@ -43,26 +37,24 @@ static scmval scm_symbol_equal_p(scm_ctx_t* ctx) {
     return scm_true;
 }
 
-static scmval scm_symbol_to_string(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
+static scmval scm_symbol_to_string(scmval v) {
+    check_arg("symbol->string", symbol_c, v);
     v.type = SCM_TYPE_STRING; // cheapest conversion ever
     return v;
 }
 
-static scmval scm_string_to_symbol(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
+static scmval scm_string_to_symbol(scmval v) {
+    check_arg("string->symbol", string_c, v);
     v.type = SCM_TYPE_SYMBOL;
     return v;
 }
 
 // initialization
-void init_symbol(scm_ctx_t* ctx) {
-    define(ctx, "symbol?", scm_symbol_p, arity_exactly(1), 1, any_c);
-    define(ctx, "symbol=?", scm_symbol_equal_p, arity_at_least(2), 1, symbol_c);
-    define(ctx, "symbol->string", scm_symbol_to_string, arity_exactly(1), 1, symbol_c);
-    define(ctx, "string->symbol", scm_string_to_symbol, arity_exactly(1), 1, string_c);
+void init_symbol() {
+    define("symbol?", scm_symbol_p, arity_exactly(1));
+    define("symbol=?", scm_symbol_equal_p, arity_at_least(2));
+    define("symbol->string", scm_symbol_to_string, arity_exactly(1));
+    define("string->symbol", scm_string_to_symbol, arity_exactly(1));
     
     scm_undef = make_val(SCM_TYPE_UNDEF);
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -26,26 +26,18 @@ scmval make_vector_from_list(int size, scmval l) {
 }
 
 // standard library
-static scmval scm_vector_p(scm_ctx_t* ctx) {
-    scmval v;
-    v = arg_ref(ctx, 0);
-    if(is_vector(v))
-        return scm_true;
-    return scm_false;
+static scmval scm_vector_p(scmval v) {
+    return scm_bool(is_vector(v));
 }
 
-static scmval scm_make_vector(scm_ctx_t* ctx) {
-    scmval r, s, i;
-    s = arg_ref(ctx, 0);
-    i = arg_ref_opt(ctx, 1, make_fixnum(0));
-    r = make_vector(fixnum_value(s), i);
-    return r;
+static scmval scm_make_vector(scmval s, scmval i) {
+    check_arg("make-vector", fixnum_c, s);
+    opt_arg(i, make_fixnum(0));
+    return make_vector(fixnum_value(s), i);
 }
 
-static scmval scm_vector(scm_ctx_t* ctx) {
-    scmval r, *argv;
-    int argc;
-    arg_ref_list(ctx, &argc, &argv);
+static scmval scm_vector(scmfix argc, scmval* argv) {
+    scmval r;
     r = make_vector(argc, scm_undef);
     for(int i = 0; i < argc; i++) {
         vector_set(r, i, argv[i]);
@@ -53,49 +45,39 @@ static scmval scm_vector(scm_ctx_t* ctx) {
     return r;
 }
 
-static scmval scm_vector_ref(scm_ctx_t* ctx) {
-    scmval r, v, i;
-    v = arg_ref(ctx, 0);
-    i = arg_ref(ctx, 1);
-    if(fixnum_value(i) < 0 || fixnum_value(i) >= vector_size(v)) {
-        scmval e = range_error("vector-ref", fixnum_value(i), vector_size(v));
-        throw(ctx, e);
-    }
+static scmval scm_vector_ref(scmval v, scmval i) {
+    check_arg("vector-ref", vector_c, v);
+    check_arg("vector-ref", fixnum_c, i);
+    scmval r;
+    if(fixnum_value(i) < 0 || fixnum_value(i) >= vector_size(v))
+        range_error("vector-ref", fixnum_value(i), vector_size(v));
     r = vector_ref(v, fixnum_value(i));
     return r;
 }
 
-static scmval scm_vector_set(scm_ctx_t* ctx) {
-    scmval v, i, x;
-    v = arg_ref(ctx, 0);
-    i = arg_ref(ctx, 1);
-    x = arg_ref(ctx, 2);
-    if(fixnum_value(i) < 0 || fixnum_value(i) >= vector_size(v)) {
-        scmval e = range_error("vector-set!", fixnum_value(i), vector_size(v));
-        throw(ctx, e);
-    }
+static scmval scm_vector_set(scmval v, scmval i, scmval x) {
+    check_arg("vector-set!", vector_c, v);
+    check_arg("vector-set!", fixnum_c, i);
+    if(fixnum_value(i) < 0 || fixnum_value(i) >= vector_size(v))
+        range_error("vector-set!", fixnum_value(i), vector_size(v));
     vector_set(v, fixnum_value(i), x);
     return scm_undef;
 }
 
-static scmval scm_vector_to_list(scm_ctx_t* ctx) {
-    scmval r, v;
-    size_t s;
-    v = arg_ref(ctx, 0);
-    s = vector_size(v);
-    r = scm_null;
+static scmval scm_vector_to_list(scmval v) {
+    check_arg("vector->list", vector_c, v);
+    scmfix s = vector_size(v);
+    scmval r = scm_null;
     for(int i = s - 1; i >= 0; i--) {
         r = cons(vector_ref(v, i), r);
     }
     return r;
 }
 
-static scmval scm_list_to_vector(scm_ctx_t* ctx) {
-    scmval r, l;
-    size_t s;
-    l = arg_ref(ctx, 0);
-    s = list_length(l);
-    r = make_vector(s, scm_undef);
+static scmval scm_list_to_vector(scmval l) {
+    check_arg("list->vector", list_c, l);
+    scmfix s = list_length(l);
+    scmval r = make_vector(s, scm_undef);
     for(int i = 0; i < s; i++, l = cdr(l)) {
         vector_set(r, i, car(l));
     }
@@ -103,13 +85,13 @@ static scmval scm_list_to_vector(scm_ctx_t* ctx) {
 }
 
 // initialization
-void init_vector(scm_ctx_t* ctx) {
-    define(ctx, "vector?", scm_vector_p, arity_exactly(1), 1, any_c);
-    define(ctx, "make-vector", scm_make_vector, arity_or(1, 2), 2, fixnum_c, any_c);
-    define(ctx, "vector", scm_vector, arity_at_least(0), 1, any_c);
-    define(ctx, "vector-ref", scm_vector_ref, arity_exactly(2), 2, vector_c, fixnum_c);
-    define(ctx, "vector-set!", scm_vector_set, arity_exactly(3), 3, vector_c, fixnum_c, any_c);
-    define(ctx, "vector->list", scm_vector_to_list, arity_exactly(1), 1, vector_c);
-    define(ctx, "list->vector", scm_list_to_vector, arity_exactly(1), 1, list_c);
+void init_vector() {
+    define("vector?", scm_vector_p, arity_exactly(1));
+    define("make-vector", scm_make_vector, arity_or(1, 2));
+    define("vector", scm_vector, arity_at_least(0));
+    define("vector-ref", scm_vector_ref, arity_exactly(2));
+    define("vector-set!", scm_vector_set, arity_exactly(3));
+    define("vector->list", scm_vector_to_list, arity_exactly(1));
+    define("list->vector", scm_list_to_vector, arity_exactly(1));
 }
 


### PR DESCRIPTION
Global rewrite/refactoring

        Changed paradigm to use plain old C functions for primitives
        instead of passing a context object and taking arguments
        from a stack stored in the context.
        I think this should be done as part of a VM implementation and
        not the base library.
        Contracts must now be enforced by primitives. The subr type do
        not have a contract attached to it anymore.
        Port types have been merged into a single scm_port_t type which
        helps simplifying implementation (or cleaning at least)
        Apart from these major changes, there was some cleanup, renaming
        and simplifications.