### PR TITLE
bytevectors implementation

### DIFF
--- a/src/bytevector.c
+++ b/src/bytevector.c
@@ -1,0 +1,177 @@
+#include "scm.h"
+
+scmval make_bytevector(size_t size, scmval initial) {
+    scm_bytevector_t* b = scm_new(scm_bytevector_t);
+    b->size = size;
+    b->elts = scm_new_array(size, scmbyte);
+    for(int i = 0; i < size; i++) {
+        b->elts[i] = fixnum_value(initial);
+    }
+    return make_ptr(SCM_TYPE_BYTEVECTOR, b);
+}
+
+scmval make_bytevector_from_list(scmfix size, scmval l) {
+    scm_bytevector_t* b = scm_new(scm_bytevector_t);
+    if(size < 0)
+        size = list_length(l);
+    b->size = size;
+    b->elts = scm_new_array(size, scmbyte);
+    int i;
+    scmval c;
+    for(c = l, i = 0; !is_null(c); c = cdr(c), i++) {
+        b->elts[i] = fixnum_value(car(c));
+    }
+    return make_ptr(SCM_TYPE_BYTEVECTOR, b);
+}
+
+// standard library
+static scmval scm_bytevector_p(scmval v) {
+    return scm_bool(is_bytevector(v));
+}
+
+static scmval scm_make_bytevector(scmval size, scmval initial) {
+    check_arg("make-bytevector", fixnum_c, size);
+    opt_arg(initial, make_fixnum(0));
+    return make_bytevector(fixnum_value(size), initial);
+}
+
+static scmval scm_bytevector(scmfix argc, scmval* argv) {
+    check_args("bytevector", byte_c, argc, argv);
+    scmval b = make_bytevector(argc, make_fixnum(0));
+    for(int i = 0; i < argc; i++) {
+        bytevector_set(b, i, argv[i]);
+    }
+    return b;
+}
+
+static scmval scm_bytevector_length(scmval b) {
+    check_arg("bytevector-length", bytevector_c, b);
+    return make_fixnum(bytevector_size(b));
+}
+
+static scmval scm_bytevector_ref(scmval b, scmval k) {
+    check_arg("bytevector-u8-ref", bytevector_c, b);
+    check_arg("bytevector-u8-ref", fixnum_c, k);
+    if(fixnum_value(k) < 0 || fixnum_value(k) >= bytevector_size(b))
+        range_error("bytevector-u8-ref", fixnum_value(k), bytevector_size(b));
+    return bytevector_ref(b, fixnum_value(k));
+}
+
+static scmval scm_bytevector_set(scmval b, scmval k, scmval byte) {
+    check_arg("bytevector-u8-set!", bytevector_c, b);
+    check_arg("bytevector-u8-set!", fixnum_c, k);
+    check_arg("bytevector-u8-set!", byte_c, byte);
+    if(fixnum_value(k) < 0 || fixnum_value(k) >= bytevector_size(b))
+        range_error("bytevector-u8-set!", fixnum_value(k), bytevector_size(b));
+    bytevector_set(b, fixnum_value(k), byte);
+    return scm_undef;
+}
+
+static scmval scm_bytevector_copy(scmval b, scmval start, scmval end) {
+    opt_arg(start, make_fixnum(0));
+    opt_arg(end, make_fixnum(bytevector_size(b)));
+    check_arg("bytevector-copy", bytevector_c, b);
+    check_arg("bytevector-copy", fixnum_c, start);
+    check_arg("bytevector-copy", fixnum_c, end);
+    if(fixnum_value(start) < 0 || fixnum_value(start) > bytevector_size(b))
+        range_error("bytevector-copy", fixnum_value(start), bytevector_size(b));
+    if(fixnum_value(end) < fixnum_value(start) || fixnum_value(end) > bytevector_size(b))
+        range_error("bytevector-copy", fixnum_value(end), bytevector_size(b));
+    scm_bytevector_t* copy = scm_new(scm_bytevector_t);
+    copy->size = fixnum_value(end) - fixnum_value(start);
+    copy->elts = scm_new_array(copy->size, scmbyte);
+    memcpy(copy->elts, get_bytevector(b)->elts+fixnum_value(start), copy->size);
+    return make_ptr(SCM_TYPE_BYTEVECTOR, copy);
+}
+
+static scmval scm_bytevector_mcopy(scmval to, scmval at, scmval from, scmval start, scmval end) {
+    opt_arg(start, make_fixnum(0));
+    opt_arg(end, make_fixnum(bytevector_size(from)));
+    check_arg("bytevector-copy!", bytevector_c, to);
+    check_arg("bytevector-copy!", fixnum_c, at);
+    check_arg("bytevector-copy!", bytevector_c, from);
+    check_arg("bytevector-copy!", fixnum_c, start);
+    check_arg("bytevector-copy!", fixnum_c, end);
+    if(fixnum_value(at) < 0 || fixnum_value(at) > bytevector_size(to))
+        range_error("bytevector-copy!", fixnum_value(at), bytevector_size(to));
+    if(fixnum_value(start) < 0 || fixnum_value(start) > bytevector_size(from))
+        range_error("bytevector-copy!", fixnum_value(start), bytevector_size(from));
+    if(fixnum_value(end) < fixnum_value(start) || fixnum_value(end) > bytevector_size(from))
+        range_error("bytevector-copy!", fixnum_value(end), bytevector_size(from));
+    if((bytevector_size(to) - fixnum_value(at)) < (fixnum_value(end) - fixnum_value(start)))
+        error(range_error_type, "bytevector-copy!: cannot fit %d elements in %s starting at index %d", 
+                (fixnum_value(end)-fixnum_value(start)), string_value(scm_to_string(to)), fixnum_value(at));
+    memcpy(get_bytevector(to)->elts + fixnum_value(at),
+           get_bytevector(from)->elts + fixnum_value(start),
+           fixnum_value(end) - fixnum_value(start));
+    return scm_undef;
+}
+
+static scmval scm_bytevector_append(scmfix argc, scmval* argv) {
+    check_args("bytevector-append", bytevector_c, argc, argv);
+    scmfix size = 0;
+    for(int i = 0; i < argc; i++) {
+        size += bytevector_size(argv[i]);
+    }
+    scm_bytevector_t* b = scm_new(scm_bytevector_t);
+    b->size = size;
+    b->elts = scm_new_array(size, scmbyte);
+    scmfix offset = 0;
+    for(int i = 0; i < argc; i++) {
+        memcpy(b->elts + offset,
+               get_bytevector(argv[i])->elts,
+               bytevector_size(argv[i]));
+        offset += bytevector_size(argv[i]);
+    }
+    return make_ptr(SCM_TYPE_BYTEVECTOR, b);
+}
+
+static scmval scm_utf8_to_string(scmval b, scmval start, scmval end) {
+    opt_arg(start, make_fixnum(0));
+    opt_arg(end  , make_fixnum(bytevector_size(b)));
+    check_arg("utf8->string", bytevector_c, b);
+    check_arg("utf8->string", fixnum_c, start);
+    check_arg("utf8->string", fixnum_c, end);
+    if(fixnum_value(start) < 0 || fixnum_value(start) > bytevector_size(b))
+        range_error("utf8->string", fixnum_value(start), bytevector_size(b));
+    if(fixnum_value(end) < fixnum_value(start) || fixnum_value(end) > bytevector_size(b))
+        range_error("utf8->string", fixnum_value(end), bytevector_size(b));
+    scmfix size = (fixnum_value(end)-fixnum_value(start)) + 1;
+    scm_char_t* s = scm_new_array(size, scm_char_t);
+    memcpy(s, get_bytevector(b)->elts + fixnum_value(start), size);
+    s[size] = '\0';
+    return make_string(s);
+}
+
+static scmval scm_string_to_utf8(scmval s, scmval start, scmval end) {
+    opt_arg(start, make_fixnum(0));
+    opt_arg(end  , make_fixnum(string_length(s)));
+    check_arg("string->utf8", string_c, s);
+    check_arg("string->utf8", fixnum_c, start);
+    check_arg("string->utf8", fixnum_c, end);
+    if(fixnum_value(start) < 0 || fixnum_value(start) > string_length(s))
+        range_error("string->utf8", fixnum_value(start), string_length(s));
+    if(fixnum_value(end) < fixnum_value(start) || fixnum_value(end) > string_length(s))
+        range_error("string->utf8", fixnum_value(end), string_length(s));
+    scm_bytevector_t* b = scm_new(scm_bytevector_t);
+    b->size = fixnum_value(end) - fixnum_value(start);
+    b->elts = scm_new_array(b->size, scmbyte);
+    memcpy(b->elts, string_to_cstr(s)+fixnum_value(start), b->size);
+    return make_ptr(SCM_TYPE_BYTEVECTOR, b);
+}
+
+void init_bytevector() {
+    define("bytevector?",        scm_bytevector_p,       arity_exactly(1));
+    define("make-bytevector",    scm_make_bytevector,    arity_or(1, 2));
+    define("bytevector",         scm_bytevector,         arity_at_least(0));
+    define("bytevector-length",  scm_bytevector_length,  arity_exactly(1));
+    define("bytevector-u8-ref",  scm_bytevector_ref,     arity_exactly(2));
+    define("bytevector-u8-set!", scm_bytevector_set,     arity_exactly(3));
+    define("bytevector-copy",    scm_bytevector_copy,    arity_between(1, 3));
+    define("bytevector-copy!",   scm_bytevector_mcopy,   arity_between(3, 5));
+    define("bytevector-append",  scm_bytevector_append,  arity_at_least(2));
+    define("utf8->string",       scm_utf8_to_string,     arity_between(1, 3));
+    define("string->utf8",       scm_string_to_utf8,     arity_between(1, 3));
+}
+
+

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@ static void scm_init() {
     init_symbol();
     init_pair();
     init_vector();
+    init_bytevector();
     init_port();
     init_reader();
     init_eval();

--- a/src/scm.h
+++ b/src/scm.h
@@ -14,6 +14,7 @@
 // type aliases
 typedef struct scmval scmval;
 typedef bool scm_bool_t;
+typedef uint8_t scmbyte;
 typedef int64_t scm_fixnum_t;
 typedef scm_fixnum_t scmfix; // used a lot
 typedef double scm_flonum_t;
@@ -32,6 +33,7 @@ enum {
     SCM_TYPE_SYMBOL,
     SCM_TYPE_PAIR,
     SCM_TYPE_VECTOR,
+    SCM_TYPE_BYTEVECTOR,
     SCM_TYPE_ENV,
     SCM_TYPE_SUBR,
     SCM_TYPE_CLOSURE,
@@ -70,6 +72,7 @@ static inline scmval make_ptr(int type, void* o) { scmval v = { .type = type, .o
 #include "scm/error.h"
 #include "scm/pair.h"
 #include "scm/vector.h"
+#include "scm/bytevector.h"
 #include "scm/port.h"
 #include "scm/proc.h"
 #include "scm/env.h"

--- a/src/scm/bytevector.h
+++ b/src/scm/bytevector.h
@@ -1,0 +1,24 @@
+typedef struct scm_bytevector scm_bytevector_t;
+
+struct scm_bytevector {
+    size_t   size;
+    scmbyte* elts;
+};
+
+// constructor
+scmval make_bytevector(size_t, scmval);
+scmval make_bytevector_from_list(scmfix, scmval);
+// accessors
+static inline scm_bytevector_t* get_bytevector(scmval v) { return (scm_bytevector_t*)v.o; }
+static inline size_t  bytevector_size(scmval v) { return get_bytevector(v)->size; }
+static inline scmval  bytevector_ref(scmval v, scmfix i) { return make_fixnum(get_bytevector(v)->elts[i]); }
+static inline void    bytevector_set(scmval v, scmfix i, scmval x) { get_bytevector(v)->elts[i] = fixnum_value(x); }
+// predicate
+static inline bool is_bytevector(scmval v) { return type_of(v) == SCM_TYPE_BYTEVECTOR; }
+static bool is_byte(scmval v) { return is_fixnum(v) && fixnum_value(v) >= 0 && fixnum_value(v) <= 255; }
+// contract
+define_contract(bytevector_c, "bytevector", is_bytevector);
+define_contract(byte_c, "byte", is_byte);
+// standard library
+void init_bytevector();
+

--- a/src/scm/string.h
+++ b/src/scm/string.h
@@ -18,5 +18,6 @@ define_contract(string_c, "string", is_string);
 
 // accessors
 static inline scm_string_t* get_string(scmval v) { return (scm_string_t*)v.o; }
-static inline CORD string_value(scmval v) { return get_string(v)->value; }
-static inline char* string_to_cstr(scmval v) { return CORD_to_char_star(string_value(v)); }
+static inline CORD          string_value(scmval v) { return get_string(v)->value; }
+static inline scmfix        string_length(scmval v) { return CORD_len(string_value(v)); }
+static inline char*         string_to_cstr(scmval v) { return CORD_to_char_star(string_value(v)); }

--- a/src/writer.c
+++ b/src/writer.c
@@ -3,6 +3,7 @@
 static void write_char(scmval, scmval, scmfix);
 static void write_pair(scmval, scmval, scmfix);
 static void write_vector(scmval, scmval, scmfix);
+static void write_bytevector(scmval, scmval, scmfix);
 
 void write(scmval p, scmval v, scmfix flags) {
     switch(type_of(v)) {
@@ -48,6 +49,9 @@ void write(scmval p, scmval v, scmfix flags) {
             break;
         case SCM_TYPE_VECTOR:
             write_vector(p, v, flags);
+            break;
+        case SCM_TYPE_BYTEVECTOR:
+            write_bytevector(p, v, flags);
             break;
         case SCM_TYPE_ENV:
             scm_puts(p, "#<environment>");
@@ -119,6 +123,15 @@ static void write_vector(scmval p, scmval v, scmfix flags) {
             scm_putc(p, ' ');
         }
         write(p, vector_ref(v, i), flags);
+    }
+    scm_putc(p, ')');
+}
+
+static void write_bytevector(scmval p, scmval v, scmfix flags) {
+    scm_puts(p, "#u8(");
+    for(int i = 0; i < bytevector_size(v); i++) {
+        if(i > 0) scm_putc(p, ' ');
+        write(p, bytevector_ref(v, i), flags);
     }
     scm_putc(p, ')');
 }


### PR DESCRIPTION
bytevector type along with all standard library functions are implemented but the conversion to and from string will fail when characters are not plain ASCII as UTF8 is not implemented (yet).